### PR TITLE
Updates go version 1.15 -> 1.16 for M1/arm support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/codekitchen/dinghy-http-proxy
 COPY join-networks.go .
+COPY go.mod .
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go get -v github.com/fsouza/go-dockerclient
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v -o join-networks
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/codekitchen/dinghy-http-proxy
+
+go 1.16
+
+require (
+    github.com/fsouza/go-dockerclient v1.7.4
+)


### PR DESCRIPTION
Ported from PR 59 in the canonical repo.

Ticket: https://ltvco.atlassian.net/browse/BOPS-493